### PR TITLE
Add support for compiled .scpt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Applescript language support for Atom. Converted from [https://github.com/textma
 
 ## Changelog
 
-* `0.2.0` Add .scpt support, store package settings in `settings/` 
+* `0.2.1` Mimic the behaviour of Apple's [Script Editor](http://help.apple.com/applescript/mac/10.9/#apscrpt1067) by automatically de/recompiling .scpt files using the native `osacompile`/`osadecompile` utilities<sup id="R1">[*](#F1)</sup>
+
+* `0.2.0` Add .scpt support, store package settings in `settings/`
 
 * `0.1.0` Initial release
+
+---
+
+<a id="F1">[*](#R1)</a> See [language-javascript-jxa](https://atom.io/packages/language-javascript-jxa) for JavaScript .scpt files.

--- a/grammars/applescript.cson
+++ b/grammars/applescript.cson
@@ -3,7 +3,7 @@
   'script editor'
   'scpt'
 ]
-'firstLineMatch': '^#!.*(osascript)'
+'firstLineMatch': '^#!.*osascript(?!.*JavaScript)|^FasdUAS'
 'name': 'AppleScript'
 'patterns': [
   {

--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,27 @@
+module.exports =
+	subs: null
+	activate: ->
+		# {name} = require './package.json' if @debug
+		{exec} = require 'child_process' #,execSync}
+#-------------------------------------------------------------------------------
+
+		#console.log "#{name} package activated." if @debug
+
+		@subs = atom.workspace.observeTextEditors (editor) ->
+			scpt = editor.getPath()
+			{scopeName} = editor.getGrammar()
+
+			if scopeName.endsWith('applescript') and scpt?.endsWith '.scpt'
+
+				# Decompile .scpt
+				stdout = exec "osadecompile '#{scpt}'" #execSync
+				stdout.stdout.on 'data', (data) -> editor.setText data #stdout.toString()
+				#console.log "#{name}: Decompiled #{scpt}." if @debug
+
+				# Recompile on save/close
+				editor.onDidDestroy -> #onDidSave
+					exec "osacompile -o '#{scpt}'{,}"
+					#console.log "#{name}: Recompiled #{scpt}." if @debug
+
+#-------------------------------------------------------------------------------
+	deactivate: -> @subs.dispose()

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "engines": {
     "atom": ">0.50.0"
   },
+  "activationHooks": [
+    "language-applescript:grammar-used"
+  ],
   "dependencies": {}
 }


### PR DESCRIPTION
Mimic the behaviour of Apple's Script Editor by automatically de/recompiling .scpt files using the native osacompile/osadecompile utilities.