### PR TITLE
Add package-setting to control auto-compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # language-applescript package
 
-Applescript language support for Atom. Converted from [https://github.com/textmate/applescript.tmbundle](https://github.com/textmate/applescript.tmbundle).
+AppleScript language support for Atom. Converted from [https://github.com/textmate/applescript.tmbundle](https://github.com/textmate/applescript.tmbundle).
 
 ## Changelog
 

--- a/index.coffee
+++ b/index.coffee
@@ -1,27 +1,54 @@
+{exec} = require 'child_process'
+{CompositeDisposable} = require 'atom'
+
 module.exports =
 	subs: null
+	autoCompiling: false
+	
 	activate: ->
-		# {name} = require './package.json' if @debug
-		{exec} = require 'child_process' #,execSync}
-#-------------------------------------------------------------------------------
+		name = "language-applescript"
+		@subs = new CompositeDisposable()
+		@subs.add atom.config.observe "#{name}.autoCompile", (newValue) =>
+			@enableAutoCompile newValue
+		
+		@subs.add atom.commands.add "body", "#{name}:decompile", => @decompile()
+		@subs.add atom.commands.add "body", "#{name}:recompile", => @recompile()
 
-		#console.log "#{name} package activated." if @debug
-
-		@subs = atom.workspace.observeTextEditors (editor) ->
-			scpt = editor.getPath()
-			{scopeName} = editor.getGrammar()
-
-			if scopeName.endsWith('applescript') and scpt?.endsWith '.scpt'
-
-				# Decompile .scpt
-				stdout = exec "osadecompile '#{scpt}'" #execSync
-				stdout.stdout.on 'data', (data) -> editor.setText data #stdout.toString()
-				#console.log "#{name}: Decompiled #{scpt}." if @debug
-
-				# Recompile on save/close
-				editor.onDidDestroy -> #onDidSave
-					exec "osacompile -o '#{scpt}'{,}"
-					#console.log "#{name}: Recompiled #{scpt}." if @debug
-
-#-------------------------------------------------------------------------------
 	deactivate: -> @subs.dispose()
+	
+#-------------------------------------------------------------------------------
+	decompile: ->
+		editor = atom.workspace.getActiveTextEditor()
+		if path = editor?.buffer.getPath()
+			task = exec "osadecompile '#{path}'"
+			task.stdout.on "data", (data) -> editor.setText data
+	
+	recompile: ->
+		editor = atom.workspace.getActiveTextEditor()
+		if path = editor?.buffer.getPath()
+			exec "osacompile -o #{path}{,}"
+
+#-------------------------------------------------------------------------------
+	enableAutoCompile: (enable) ->
+		if enable and not @autoCompiling
+			@autoCompiling = true
+			
+			@subs.add @watchEditors = atom.workspace.observeTextEditors (editor) =>
+				scpt = editor.getPath()
+				{scopeName} = editor.getGrammar()
+
+				if scopeName.endsWith('applescript') and scpt?.endsWith '.scpt'
+
+					# Decompile .scpt
+					stdout = exec "osadecompile '#{scpt}'"
+					stdout.stdout.on 'data', (data) -> editor.setText data
+
+					# Recompile on save/close
+					editor.onDidDestroy =>
+						if @autoCompiling then exec "osacompile -o '#{scpt}'{,}"
+			
+		else if not enable
+			@autoCompiling = false
+			if @watchEditors?
+				@watchEditors.dispose()
+				@subs.remove @watchEditors

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "language-applescript",
   "version": "0.2.2",
   "private": true,
-  "description": "Applescript language support for Atom. Converted from https://github.com/textmate/applescript.tmbundle.",
+  "description": "AppleScript language support for Atom. Converted from https://github.com/textmate/applescript.tmbundle.",
   "repository": "https://github.com/franzheidl/atom-applescript",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -11,5 +11,13 @@
   "activationHooks": [
     "language-applescript:grammar-used"
   ],
+  "configSchema": {
+    "autoCompile": {
+      "type": "boolean",
+      "default": true,
+      "title": "Auto-compile",
+      "description": "Automatically decompile (and recompile) `.scpt` files using native `osacompile`/`osadecompile` utilities."
+    }
+  },
   "dependencies": {}
 }


### PR DESCRIPTION
I can't speak for all users, but I find it incredibly disconcerting to see files being compiled without my consent (and initially, without my knowledge). I had to save [this file](https://github.com/Alhadis/AddressPrinter/blob/master/close.scpt) using Emacs instead of Atom just to avoid committing a binary file to my project's repository. :p

This PR places the auto-compilation feature under the control of a new package setting, which is on by default (so there's no change of functionality being forced on users). It looks like this:

<img src="https://cloud.githubusercontent.com/assets/2346707/17324386/ab278d0c-58e9-11e6-94cf-db24ae3f3ba9.png" width="623" alt="Figure 1" />

I also added two commands to manually decompile/recompile AppleScripts, although they're not assigned any keymappings by default. Users who prefer the autocompilation feature be disabled are free to map them to whatever shortcuts they please (or run the commands through the Command Palette).

I've only performed cursory testing: you might want to test it more thoroughly in case I've missed anything. Should be fine, though. =)
