### PR TITLE
Improve comment syntax highlighting

### DIFF
--- a/grammars/applescript.cson
+++ b/grammars/applescript.cson
@@ -821,7 +821,7 @@
   'comments':
     'patterns': [
       {
-        'begin': '^\\s*(#!)'
+        'begin': '#'
         'captures':
           '1':
             'name': 'punctuation.definition.comment.applescript'


### PR DESCRIPTION
`#` also count as comments in AppleScript. Fixes #12.
