### PR TITLE
Used insertText() instead of setText() to handle large scripts

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -4,25 +4,25 @@
 module.exports =
 	subs: null
 	autoCompiling: false
-	
+
 	activate: ->
 		name = "language-applescript"
 		@subs = new CompositeDisposable()
 		@subs.add atom.config.observe "#{name}.autoCompile", (newValue) =>
 			@enableAutoCompile newValue
-		
+
 		@subs.add atom.commands.add "body", "#{name}:decompile", => @decompile()
 		@subs.add atom.commands.add "body", "#{name}:recompile", => @recompile()
 
 	deactivate: -> @subs.dispose()
-	
+
 #-------------------------------------------------------------------------------
 	decompile: ->
 		editor = atom.workspace.getActiveTextEditor()
 		if path = editor?.buffer.getPath()
 			task = exec "osadecompile '#{path}'"
 			task.stdout.on "data", (data) -> editor.setText data
-	
+
 	recompile: ->
 		editor = atom.workspace.getActiveTextEditor()
 		if path = editor?.buffer.getPath()
@@ -32,7 +32,7 @@ module.exports =
 	enableAutoCompile: (enable) ->
 		if enable and not @autoCompiling
 			@autoCompiling = true
-			
+
 			@subs.add @watchEditors = atom.workspace.observeTextEditors (editor) =>
 				scpt = editor.getPath()
 				{scopeName} = editor.getGrammar()
@@ -41,12 +41,13 @@ module.exports =
 
 					# Decompile .scpt
 					stdout = exec "osadecompile '#{scpt}'"
-					stdout.stdout.on 'data', (data) -> editor.setText data
+					editor.setText ""
+					stdout.stdout.on 'data', (data) -> editor.insertText data
 
 					# Recompile on save/close
 					editor.onDidDestroy =>
 						if @autoCompiling then exec "osacompile -o '#{scpt}'{,}"
-			
+
 		else if not enable
 			@autoCompiling = false
 			if @watchEditors?


### PR DESCRIPTION
Since setText() cuts all data larger than ~200 lines, I set editor.setText to "" and then added data from decompiler by insertText(). Please take a look, lines 44-45.